### PR TITLE
properly dereference the WeakRef when getting derived cells from a cell

### DIFF
--- a/library/classes.js
+++ b/library/classes.js
@@ -176,7 +176,7 @@ export class Cell {
    */
   get derivedCells() {
     // @ts-ignore
-    return this.#derivedCells.map((cell) => cell.deref()).filter(Boolean);
+    return this.#derivedCells.map((cell) => cell[0].deref()).filter(Boolean);
   }
 
   /**

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -733,3 +733,14 @@ describe('SourceCell deproxy', () => {
     }).toThrowError('Cannot deproxy a non-object cell.');
   });
 });
+
+describe('Derived Cells', () => {
+  test('derived cells should be available', () => {
+
+    const s = Cell.source(1);
+    const f = Cell.derived(() => s.value + 1);
+
+    const derived = s.derivedCells
+    expect(derived).toEqual([f]);
+  })
+})


### PR DESCRIPTION
Hey there!

Wonderful work on this - i'm hoping to integrate it into a project, and since the release of svelte 5 have been working to architect a unification of my backend and front end with signals on either end... all this to say i'm very invested in this library and and excited to see it develop. 

I did run into a bug with getting the `derivedCells` from a cell. I think i've provided a fix here, please let me know if there's anything I missed in testing!

Best
Trev