### PR TITLE
Separate derived cell lifecycle from weak references

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ const user = Cell.source(
 
 #### Memory Management (Contexts)
 
-For high-performance scenarios involving many dynamically created cells, use `LocalContext` for manual disposal.
+Cells keep their derived dependents strongly referenced so updates remain deterministic. For high-performance scenarios involving many dynamically created cells, use `LocalContext` to dispose of those derivations explicitly.
 
 ```javascript
 const ctx = Cell.context();

--- a/library/classes.js
+++ b/library/classes.js
@@ -56,7 +56,7 @@ let BATCHED_EFFECTS = new Map();
  * A value representing the computed values that are currently being calculated,
  * and the largest depth encountered.
  * It is an array so it can keep track of nested computed values.
- * @type {[DerivedCell<any>, number][]}
+ * @type {[DerivedCell<any>, number, Set<Cell<any>>][]}
  */
 const ACTIVE_DERIVED_CTX = [];
 
@@ -65,7 +65,9 @@ let CurrentTrackingContext = GlobalTrackingContext;
 const Depth = Symbol();
 const IsScheduled = Symbol();
 const Deferred = Symbol();
+const DisposeCell = Symbol();
 const DisposeAsyncCell = Symbol();
+const IsDisposed = Symbol();
 
 /**
  * Tracks cells that need to be updated during the update cycle.
@@ -212,8 +214,8 @@ class Effect {
 }
 
 export class LocalContext {
-  /** @type {Map<DerivedCell<any>, Set<Cell<any>>>} */
-  derivationSourceMap = new Map();
+  /** @type {Set<DerivedCell<any>>} */
+  derivations = new Set();
   /** @type {Map<Cell<any>, Set<Effect<any>>>} */
   effects = new Map();
 
@@ -222,26 +224,19 @@ export class LocalContext {
       throw new Error('Cannot destroy a context inside its callback.');
     }
 
-    for (const [derivation, sources] of this.derivationSourceMap) {
-      for (const source of sources) {
-        source.derivations.delete(derivation);
-      }
+    for (const derivation of this.derivations) {
+      derivation[DisposeCell]();
       if (derivation instanceof AsyncCell) derivation[DisposeAsyncCell]();
     }
 
     for (const [cell, effects] of this.effects) {
-      if (cell instanceof DerivedCell && this.derivationSourceMap.has(cell)) {
-        // There is no point to ignoring the listener, since it will be disposed
-        // and unreachable on the graph anyway.
-        continue;
-      }
-
       for (const effect of effects) {
-        if (effect.callback !== undefined) cell.ignore(effect.callback);
+        const callback = effect.callback;
+        if (callback !== undefined) cell.ignore(callback);
       }
     }
 
-    this.derivationSourceMap.clear();
+    this.derivations.clear();
     this.effects.clear();
   }
 }
@@ -298,6 +293,7 @@ export class Cell {
    * @protected
    */
   [IsScheduled] = false;
+  [IsDisposed] = false;
 
   /**
    * @type {Array<Effect<T>>}
@@ -355,19 +351,15 @@ export class Cell {
     }
 
     const [currentlyComputedValue] = ctx;
-    const isAlreadySubscribed = this.derivations.has(currentlyComputedValue);
-    if (isAlreadySubscribed) {
+    if (this[IsDisposed] || currentlyComputedValue[IsDisposed]) {
       return this.wvalue;
     }
     if (this instanceof DerivedCell && this[Depth] > ctx[1]) {
       ctx[1] = this[Depth];
     }
     this.derivations.add(currentlyComputedValue);
-    if (CurrentTrackingContext instanceof LocalContext) {
-      CurrentTrackingContext.derivationSourceMap
-        .get(currentlyComputedValue)
-        ?.add(this);
-    }
+    currentlyComputedValue.sources.add(this);
+    ctx[2].add(this);
     return this.wvalue;
   }
 
@@ -840,27 +832,38 @@ export class DerivedCell extends Cell {
   [Depth] = 0;
   [Deferred] = false;
 
+  /** @type {Set<Cell<any>>} */
+  sources = new Set();
+
   /**
    * @param {() => T} computedFn - A function that generates the value of the computed.
    */
   constructor(computedFn) {
     super();
     if (CurrentTrackingContext instanceof LocalContext) {
-      CurrentTrackingContext.derivationSourceMap.set(this, new Set());
+      CurrentTrackingContext.derivations.add(this);
     }
 
     // Ensures that the cell is derived every time the computing function is called.
     const derivationWrapper = () => {
-      ACTIVE_DERIVED_CTX.push([this, 0]);
+      if (this[IsDisposed]) return this.wvalue;
+
+      const nextSources = new Set();
+      ACTIVE_DERIVED_CTX.push([this, 0, nextSources]);
       try {
         return computedFn();
       } catch (e) {
         if (e instanceof Error) cellErrors.push(e);
         return this.wvalue;
       } finally {
-        const i = /** @type {[this, number]} */ (ACTIVE_DERIVED_CTX.pop());
-        const [, depth] = i;
-        if (depth + 1 > this[Depth]) this[Depth] = depth + 1;
+        const [, depth] = /** @type {[this, number, Set<Cell<any>>]} */ (
+          ACTIVE_DERIVED_CTX.pop()
+        );
+        for (const source of this.sources) {
+          if (!nextSources.has(source)) source.derivations.delete(this);
+        }
+        this.sources = nextSources;
+        this[Depth] = depth + 1;
       }
     };
 
@@ -868,6 +871,19 @@ export class DerivedCell extends Cell {
     this.wvalue = derivationWrapper();
     this.computedFn = /** @type {() => T} */ (derivationWrapper);
     throwAnyErrors();
+  }
+
+  [DisposeCell]() {
+    if (this[IsDisposed]) return;
+    this[IsDisposed] = true;
+
+    for (const source of this.sources) source.derivations.delete(this);
+    this.sources.clear();
+
+    for (const derivation of this.derivations) {
+      derivation.sources.delete(this);
+    }
+    this.derivations.clear();
   }
 
   /** @type {() => T} */
@@ -994,32 +1010,38 @@ export class AsyncCell extends DerivedCell {
     const initialState = /** @type {Promise<T>} */ (Promise.resolve(null));
     super(() => initialState);
     let lastStablePromise = initialState;
-    /** @type [this, number] */
-    let derivedCtx = [this, this[Depth]];
     let runId = 0;
 
-    /**
-     * @template T
-     * @param {Cell<T>} cell
-     * @returns {T}
-     */
-    const get = (cell) => {
-      ACTIVE_DERIVED_CTX.push(derivedCtx);
-      const value = cell.get();
-      if (cell instanceof AsyncCell && value instanceof Promise) {
-        const currentRunId = runId;
-        value.then(() => {
-          if (runId === currentRunId) this.#consumed.add(cell);
-        });
-      }
-      ACTIVE_DERIVED_CTX.pop();
-      return value;
-    };
-
     this.computedFn = async () => {
+      if (this[IsDisposed]) return this.wvalue;
+
       const currentRunId = ++runId;
+      const derivedCtx = /** @type {[this, number, Set<Cell<any>>]} */ (
+        [this, 0, new Set()]
+      );
       this.#consumed.clear();
-      derivedCtx = [this, this[Depth]];
+
+      /**
+       * @template X
+       * @param {Cell<X>} cell
+       * @returns {X}
+       */
+      const get = (cell) => {
+        if (currentRunId !== runId || this[IsDisposed]) return cell.peek();
+
+        ACTIVE_DERIVED_CTX.push(derivedCtx);
+        try {
+          const value = cell.get();
+          if (cell instanceof AsyncCell && value instanceof Promise) {
+            value.then(() => {
+              if (runId === currentRunId) this.#consumed.add(cell);
+            });
+          }
+          return value;
+        } finally {
+          ACTIVE_DERIVED_CTX.pop();
+        }
+      };
 
       Cell.batch(() => {
         this.pending.set(true);
@@ -1077,14 +1099,21 @@ export class AsyncCell extends DerivedCell {
       this.#abandonLastComputation = abandonComputation;
 
       current.finally(async () => {
-        if (currentRunId !== runId) return;
+        if (currentRunId !== runId || this[IsDisposed]) return;
+
+        const nextSources = derivedCtx[2];
+        for (const source of this.sources) {
+          if (!nextSources.has(source)) source.derivations.delete(this);
+        }
+        this.sources = nextSources;
+        this[Depth] = derivedCtx[1] + 1;
+
         if (lastStablePromise === initialState) {
           // We only run update() for subsequent changes, not initial resolution.
           lastStablePromise = current;
           return;
         }
         lastStablePromise = current;
-        if (derivedCtx[1] + 1 > this[Depth]) this[Depth] = derivedCtx[1] + 1;
         if (await valueHasChanged) this.update();
       });
 
@@ -1109,6 +1138,7 @@ export class AsyncCell extends DerivedCell {
       // Grandchildren will be scheduled by their direct parent when it computes.
       promise.then(async () => {
         child.#upstream.delete(promise);
+        if (this[IsDisposed] || child[IsDisposed]) return;
         if (lastStablePromise === initialState) {
           return;
         }

--- a/library/classes.js
+++ b/library/classes.js
@@ -957,6 +957,10 @@ export class AsyncCell extends DerivedCell {
   #abandonLastComputation;
   /** @type {AbortController | undefined} */
   #controller;
+  /** @type {Promise<void>} */
+  #pendingPromise;
+  /** @type {undefined | (() => void)} */
+  #resolvePending;
 
   /**
    * @protected
@@ -998,17 +1002,21 @@ export class AsyncCell extends DerivedCell {
   constructor(fn) {
     const initialState = /** @type {Promise<T>} */ (Promise.resolve(null));
     super(() => initialState);
+    this.#pendingPromise = new Promise((resolve) => {
+      this.#resolvePending = resolve;
+    });
     let lastStablePromise = initialState;
+    let lastStableValue = /** @type {T | null} */ (null);
     let runId = 0;
 
-    this.computedFn = async () => {
+    this.computedFn = () => {
       if (this[IsDisposed]) return this.wvalue;
 
       const currentRunId = ++runId;
+      this.#consumed.clear();
       const derivedCtx = /** @type {[this, number, Set<Cell<any>>]} */ (
         [this, 0, new Set()]
       );
-      this.#consumed.clear();
 
       /**
        * @template X
@@ -1032,20 +1040,25 @@ export class AsyncCell extends DerivedCell {
         }
       };
 
-      Cell.batch(() => {
-        this.pending.set(true);
-        this.error.set(null);
-      });
+      const wasPending = this.pending.peek();
+      const hadError = this.error.peek() !== null;
+      if (!wasPending) {
+        this.#pendingPromise = new Promise((resolve) => {
+          this.#resolvePending = resolve;
+        });
+      }
+      if (!wasPending || hadError) {
+        Cell.batch(() => {
+          if (!wasPending) this.pending.set(true);
+          if (hadError) this.error.set(null);
+        });
+      }
+      if (currentRunId !== runId) return this.wvalue;
 
       this.#controller?.abort();
       this.#controller = new AbortController();
 
-      /** @type {null | ((value: boolean) => void)} */
-      let resolveChangedState = null;
-      /** @type {Promise<boolean>} */
-      const valueHasChanged = new Promise((resolve) => {
-        resolveChangedState = resolve;
-      });
+      const state = { changed: false, failed: false };
       // if this cell discards this promise and starts another,
       // we do not want to its children to be stuck waiting for the old.
       // We are not using signal.addEventListener('abort') here because
@@ -1054,40 +1067,52 @@ export class AsyncCell extends DerivedCell {
       // so they don't resolve prematurely.
       /** @type {undefined | (() => void)} */
       let abandonComputation;
-      /** @type {Promise<T | null>} */
+      /** @type {Promise<T>} */
       const tripwire = new Promise((resolve) => {
         abandonComputation = () => resolve(lastStablePromise);
       });
 
-      const current = Promise.race([
-        tripwire,
-        new Promise((resolve) => resolve(fn(get, this._signal))),
-      ])
+      /** @type {Promise<T>} */
+      let computation;
+      try {
+        computation = /** @type {Promise<T>} */ (
+          Promise.resolve(fn(get, this._signal))
+        );
+      } catch (error) {
+        computation = Promise.reject(error);
+      }
+
+      const current = Promise.race([tripwire, computation])
         .catch((error) => {
+          state.failed = true;
           if (currentRunId === runId) {
+            const resolvePending = this.#resolvePending;
+            this.#resolvePending = undefined;
             Cell.batch(() => {
               this.pending.set(false);
               this.error.set(error);
             });
+            resolvePending?.();
           }
           return lastStablePromise;
         })
-        .then(async (value) => {
-          if (currentRunId === runId) {
+        .then((value) => {
+          if (currentRunId === runId && !state.failed) {
+            const resolvePending = this.#resolvePending;
+            this.#resolvePending = undefined;
+            state.changed = !deepEqual(lastStableValue, value);
             this.pending.set(false);
-            resolveChangedState?.(!deepEqual(await lastStablePromise, value));
-          } else {
-            resolveChangedState?.(false);
+            resolvePending?.();
           }
           return value;
         });
       this.wvalue = current;
 
-      this.#notify(current, valueHasChanged, lastStablePromise, initialState);
+      this.#notify(current, state, lastStablePromise, initialState);
       this.#abandonLastComputation?.();
       this.#abandonLastComputation = abandonComputation;
 
-      current.finally(async () => {
+      current.then((value) => {
         if (currentRunId !== runId || this[IsDisposed]) return;
 
         const nextSources = derivedCtx[2];
@@ -1096,6 +1121,7 @@ export class AsyncCell extends DerivedCell {
         }
         this.sources = nextSources;
         this[Depth] = derivedCtx[1] + 1;
+        lastStableValue = value;
 
         if (lastStablePromise === initialState) {
           // We only run update() for subsequent changes, not initial resolution.
@@ -1103,7 +1129,7 @@ export class AsyncCell extends DerivedCell {
           return;
         }
         lastStablePromise = current;
-        if (await valueHasChanged) this.update();
+        if (state.changed) this.update();
       });
 
       return this.wvalue;
@@ -1114,18 +1140,18 @@ export class AsyncCell extends DerivedCell {
 
   /**
    * @param {Promise<any>} promise
-   * @param {Promise<boolean>} valueHasChanged
+   * @param {{ changed: boolean }} state
    * @param {Promise<any>} lastStablePromise
    * @param {Promise<any>} initialState
    */
-  #notify(promise, valueHasChanged, lastStablePromise, initialState) {
+  #notify(promise, state, lastStablePromise, initialState) {
     for (const child of this.derivations) {
       if (!(child instanceof AsyncDerivedCell)) continue;
       if (child.#upstream.has(promise)) continue;
 
-      // Only direct children should be scheduled based on this cell's valueHasChanged.
+      // Only direct children should be scheduled based on this cell's value change.
       // Grandchildren will be scheduled by their direct parent when it computes.
-      promise.then(async () => {
+      promise.then(() => {
         child.#upstream.delete(promise);
         if (this[IsDisposed] || child[IsDisposed]) return;
         if (lastStablePromise === initialState) {
@@ -1137,7 +1163,8 @@ export class AsyncCell extends DerivedCell {
         if (child.pending.peek() && !child.#consumed.has(this)) {
           return;
         }
-        if (!child[IsScheduled] && (await valueHasChanged)) {
+        if (!child[IsScheduled] && state.changed) {
+          child[IsScheduled] = true;
           UPDATE_BUFFER.push(child);
           if (!IS_UPDATING) triggerUpdate();
         }
@@ -1171,14 +1198,17 @@ export class AsyncCell extends DerivedCell {
    * Returns the current value of the async cell.
    * @returns {Promise<T>}
    */
-  async get() {
+  get() {
     super.get(); // Forces a dependency registration in sync time.
-    while (this.#upstream.size) await Promise.allSettled([...this.#upstream]);
-    return new Promise((resolve) => {
-      if (this.pending.peek()) {
-        this.pending.listen(() => resolve(this.wvalue), { once: true });
-      } else resolve(this.wvalue);
-    });
+    if (this.#upstream.size === 0 && !this.pending.peek()) return this.wvalue;
+
+    return (async () => {
+      while (this.#upstream.size) {
+        await Promise.allSettled(this.#upstream);
+      }
+      if (this.pending.peek()) await this.#pendingPromise;
+      return this.wvalue;
+    })();
   }
 
   [DisposeAsyncCell]() {
@@ -1191,15 +1221,16 @@ export class AsyncCell extends DerivedCell {
    * but it does not register this cell as a dependency of the calling context.
    * @returns {Promise<T>} A promise that resolves to the current value.
    */
-  async peek() {
-    while (this.#upstream.size) await Promise.allSettled([...this.#upstream]);
-    return new Promise((resolve) => {
-      if (this.pending.peek()) {
-        this.pending.listen(() => resolve(this.wvalue), { once: true });
-      } else {
-        resolve(this.wvalue);
+  peek() {
+    if (this.#upstream.size === 0 && !this.pending.peek()) return this.wvalue;
+
+    return (async () => {
+      while (this.#upstream.size) {
+        await Promise.allSettled(this.#upstream);
       }
-    });
+      if (this.pending.peek()) await this.#pendingPromise;
+      return this.wvalue;
+    })();
   }
 }
 
@@ -1385,9 +1416,8 @@ export class AsyncTaskCell extends AsyncCell {
      * const anotherUser = await task.runWith(456);
      * ```
      */
-    this.runWith = async (input) => {
+    this.runWith = (input) => {
       const isFirstExecution = !hasExecuted;
-      this.abort();
       currentInput = input;
       hasInput = true;
       const value = this.computedFn();

--- a/library/classes.js
+++ b/library/classes.js
@@ -154,9 +154,10 @@ function triggerUpdate() {
     for (; i < UPDATE_BUFFER.length; i++) {
       const cell = UPDATE_BUFFER[i];
       if (cell[IsScheduled]) {
+        // Clear before notifying so a re-entrant write can schedule a new pass.
+        cell[IsScheduled] = false;
         // @ts-expect-error: Cell.update is protected.
         cell.update();
-        cell[IsScheduled] = false;
       }
     }
   }
@@ -211,6 +212,25 @@ class Effect {
     }
     return this.#callback;
   }
+}
+
+/**
+ * Inserts an effect after existing effects with the same priority.
+ * @template T
+ * @param {Effect<T>[]} effects
+ * @param {Effect<T>} effect
+ */
+function insertEffect(effects, effect) {
+  const priority = effect.options?.priority ?? 0;
+  let low = 0;
+  let high = effects.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    const middlePriority = effects[middle].options?.priority ?? 0;
+    if (middlePriority >= priority) low = middle + 1;
+    else high = middle;
+  }
+  effects.splice(low, 0, effect);
 }
 
 export class LocalContext {
@@ -393,18 +413,9 @@ export class Cell {
 
     if (!isAlreadySubscribed) {
       const effectContainer = new Effect(effect, options);
-      this.#effects.push(effectContainer);
-
+      insertEffect(this.#effects, effectContainer);
       addEffectToCurrentContext(this, effectContainer);
     }
-
-    this.#effects.sort((a, b) => {
-      const aPriority = a.options?.priority ?? 0;
-      const bPriority = b.options?.priority ?? 0;
-
-      if (aPriority === bPriority) return 0;
-      return aPriority < bPriority ? 1 : -1;
-    });
 
     return () => this.ignore(effect);
   }
@@ -442,16 +453,9 @@ export class Cell {
 
     if (!isAlreadySubscribed) {
       const effectContainer = new Effect(cb, options);
-      this.#effects.push(effectContainer);
+      insertEffect(this.#effects, effectContainer);
       addEffectToCurrentContext(this, effectContainer);
     }
-
-    this.#effects.sort((a, b) => {
-      const aPriority = a.options?.priority ?? 0;
-      const bPriority = b.options?.priority ?? 0;
-      if (aPriority === bPriority) return 0;
-      return aPriority < bPriority ? 1 : -1;
-    });
 
     throwAnyErrors();
 
@@ -759,15 +763,11 @@ export class Cell {
    * @returns {X} The return value of the callback.
    */
   static batch = (callback) => {
-    const currentBatchLevel = BATCH_NESTING_LEVEL;
-    const currentUpdateBuffer = UPDATE_BUFFER;
     const wasUpdating = IS_UPDATING;
-    const currentBatchedEffects = BATCHED_EFFECTS;
+    const isOutermost = BATCH_NESTING_LEVEL === 0;
 
-    UPDATE_BUFFER = [];
     IS_UPDATING = true;
     BATCH_NESTING_LEVEL++;
-    BATCHED_EFFECTS = new Map();
     /** @type {X | undefined} */
     let value;
     try {
@@ -776,37 +776,24 @@ export class Cell {
       } catch (e) {
         if (e instanceof Error) cellErrors.push(e);
       }
-      if (!wasUpdating) triggerUpdate();
+      if (isOutermost && !wasUpdating) triggerUpdate();
     } catch (e) {
       if (e instanceof Error) cellErrors.push(e);
     } finally {
-      BATCH_NESTING_LEVEL = currentBatchLevel;
-      if (BATCH_NESTING_LEVEL === 0) {
-        for (const [effect, value] of BATCHED_EFFECTS) {
+      BATCH_NESTING_LEVEL--;
+      IS_UPDATING = wasUpdating;
+
+      if (isOutermost) {
+        const effects = BATCHED_EFFECTS;
+        BATCHED_EFFECTS = new Map();
+        for (const [effect, effectValue] of effects) {
           try {
-            effect(value);
+            effect(effectValue);
           } catch (e) {
             if (e instanceof Error) cellErrors.push(e);
           }
         }
-      } else {
-        // Merge nested batch effects into parent batch so they're not lost
-        for (const [effect, value] of BATCHED_EFFECTS) {
-          currentBatchedEffects.set(effect, value);
-        }
       }
-
-      // Merge any cells scheduled for update into the parent buffer
-      for (const cell of UPDATE_BUFFER) {
-        if (!currentUpdateBuffer.includes(cell)) {
-          currentUpdateBuffer.push(cell);
-        }
-      }
-
-      UPDATE_BUFFER = currentUpdateBuffer;
-      IS_UPDATING = wasUpdating;
-      BATCH_NESTING_LEVEL = currentBatchLevel;
-      BATCHED_EFFECTS = currentBatchedEffects;
     }
     throwAnyErrors();
     return /** @type {X} */ (value);
@@ -949,8 +936,10 @@ export class SourceCell extends Cell {
     if (isEqual) return;
 
     this.wvalue = value;
-    this[IsScheduled] = true;
-    UPDATE_BUFFER.push(this);
+    if (!this[IsScheduled]) {
+      this[IsScheduled] = true;
+      UPDATE_BUFFER.push(this);
+    }
     if (!IS_UPDATING) triggerUpdate();
   }
 }

--- a/library/classes.js
+++ b/library/classes.js
@@ -60,53 +60,6 @@ let BATCHED_EFFECTS = new Map();
  */
 const ACTIVE_DERIVED_CTX = [];
 
-/**
- * @template {WeakKey & { ref: WeakRef<any> | null }} Value
- * @extends {Set<Value>}
- */
-class InternallyWeakSet {
-  /** @type {Set<WeakRef<Value>>} */
-  #internal = new Set();
-
-  /** @param {Value} value */
-  add(value) {
-    if (value.ref === null) value.ref = new WeakRef(value);
-    this.#internal.add(value.ref);
-    return this;
-  }
-
-  /** @param {Value} value */
-  delete(value) {
-    if (value.ref === null) return false;
-    return this.#internal.delete(value.ref);
-  }
-
-  /** @param {Value} value */
-  has(value) {
-    if (value.ref === null) return false;
-    return this.#internal.has(value.ref);
-  }
-
-  *[Symbol.iterator]() {
-    for (const ref of this.#internal) {
-      const value = ref.deref();
-      if (value) yield value;
-      else this.#internal.delete(ref); // Cleanup dead refs while iterating
-    }
-  }
-}
-
-/**
- * @template {WeakKey & { ref: WeakRef<any> | null }}  Value
- * @typedef {InternallyWeakSet<Value> | Set<Value>} SetLike
- */
-
-/**
- * @template {WeakKey & { ref: WeakRef<any> | null }} Key
- * @template Value
- * @typedef {Map<Key, Value> | WeakMap<Key, Value>} MapLike
- */
-
 const GlobalTrackingContext = {};
 let CurrentTrackingContext = GlobalTrackingContext;
 const Depth = Symbol();
@@ -351,22 +304,14 @@ export class Cell {
    */
   #effects = [];
 
-  /** @type {WeakRef<this> | null} */
-  ref = null;
-
   constructor() {
     if (new.target === Cell) {
       throw new Error(
         'Cell should not be instantiated directly. Use `Cell.source` or `Cell.derived` instead.',
       );
     }
-    /**
-     * @type {SetLike<DerivedCell<any>>}
-     */
-    this.derivations =
-      CurrentTrackingContext === GlobalTrackingContext
-        ? new InternallyWeakSet()
-        : new Set();
+    /** @type {Set<DerivedCell<any>>} */
+    this.derivations = new Set();
   }
 
   /**

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3616,9 +3616,13 @@ describe('Tracking contexts', () => {
 				});
 			});
 
+			expect(source.derivations).toBeInstanceOf(Set);
+			expect(source.derivations.size).toBe(1);
+
 			source.set(20);
 			expect(derivedValue).toBe(40);
 			context.destroy();
+			expect(source.derivations.size).toBe(0);
 			source.set(30);
 
 			expect(derivedValue).toBe(40);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -175,6 +175,38 @@ describe('Effects', () => {
 		expect(callback).toHaveBeenCalledTimes(1);
 	});
 
+	test('Cell should reschedule same-cell writes made by an effect', () => {
+		const cell = Cell.source(0);
+		const values = [];
+
+		cell.listen((value) => {
+			values.push(value);
+			if (value === 1) cell.set(2);
+		});
+
+		cell.set(1);
+
+		expect(values).toEqual([1, 2]);
+		expect(cell.get()).toBe(2);
+	});
+
+	test('Nested batches should preserve re-entrant same-cell writes', () => {
+		const cell = Cell.source(0);
+		const values = [];
+
+		cell.listen((value) => {
+			values.push(value);
+			if (value === 1) {
+				Cell.batch(() => cell.set(2));
+			}
+		});
+
+		cell.set(1);
+
+		expect(values).toEqual([1, 2]);
+		expect(cell.get()).toBe(2);
+	});
+
 	test('Cells should have updated values when read in effects', () => {
 		const cell = Cell.source(1);
 		const derivedCell = Cell.derived(() => cell.get() * 2);
@@ -1067,6 +1099,75 @@ describe('Batched effects', () => {
 		});
 
 		expect(order).toBe('ABC');
+	});
+
+	test('Default-priority listeners should precede negative priorities', () => {
+		const cell = Cell.source(0);
+		let order = '';
+
+		cell.listen(() => (order += 'N'), { priority: -1 });
+		cell.listen(() => (order += 'D'));
+		cell.set(1);
+
+		expect(order).toBe('DN');
+	});
+
+	test('Equal-priority listeners preserve registration order', () => {
+		const cell = Cell.source(0);
+		let order = '';
+
+		cell.listen(() => (order += 'A'), { priority: 1 });
+		cell.listen(() => (order += 'B'), { priority: 1 });
+		cell.listen(() => (order += 'C'), { priority: 1 });
+		cell.set(1);
+
+		expect(order).toBe('ABC');
+	});
+
+	test('runAndListen should preserve default and negative priority order', () => {
+		const cell = Cell.source(0);
+		let order = '';
+
+		cell.runAndListen(() => (order += 'N'), { priority: -1 });
+		cell.runAndListen(() => (order += 'D'));
+		order = '';
+		cell.set(1);
+
+		expect(order).toBe('DN');
+	});
+
+	test('Nested batches should notify once with the final value', () => {
+		const cell = Cell.source(0);
+		const callback = vi.fn();
+		cell.listen(callback);
+
+		Cell.batch(() => {
+			cell.set(1);
+			Cell.batch(() => {
+				cell.set(2);
+				cell.set(3);
+			});
+			cell.set(4);
+		});
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(callback).toHaveBeenCalledWith(4);
+	});
+
+	test('Batched listeners can start isolated nested batches', () => {
+		const source = Cell.source(0);
+		const target = Cell.source(0);
+		const values = [];
+
+		source.listen((value) => {
+			values.push(`source:${value}`);
+			Cell.batch(() => target.set(value * 2));
+		});
+		target.listen((value) => values.push(`target:${value}`));
+
+		Cell.batch(() => source.set(3));
+
+		expect(values).toEqual(['source:3', 'target:6']);
 	});
 
 	test('Batch with conditional derived cell updates', () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1524,6 +1524,55 @@ describe('Cell.derivedAsync', () => {
 			expect(await asyncCell.get()).toBe(20);
 		});
 
+		test('completion listeners can restart without stranding pending reads', async () => {
+			const source = Cell.source(1);
+			const asyncCell = Cell.derivedAsync(async (get) => {
+				const value = get(source);
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				return value;
+			});
+			let restarted = false;
+			asyncCell.pending.listen((isPending) => {
+				if (!isPending && !restarted) {
+					restarted = true;
+					source.set(2);
+				}
+			});
+
+			const read = asyncCell.get();
+			await vi.advanceTimersByTimeAsync(30);
+
+			expect(await read).toBe(2);
+			expect(await asyncCell.get()).toBe(2);
+			expect(asyncCell.pending.get()).toBe(false);
+		});
+
+		test('pending listeners can replace a run during startup', async () => {
+			const source = Cell.source(1);
+			const asyncCell = Cell.derivedAsync(async (get) => {
+				const value = get(source);
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				return value;
+			});
+
+			await vi.advanceTimersByTimeAsync(10);
+			expect(await asyncCell.get()).toBe(1);
+
+			let restarted = false;
+			asyncCell.pending.listen((isPending) => {
+				if (isPending && !restarted) {
+					restarted = true;
+					source.set(3);
+				}
+			});
+
+			source.set(2);
+			await vi.advanceTimersByTimeAsync(20);
+
+			expect(await asyncCell.get()).toBe(3);
+			expect(asyncCell.pending.get()).toBe(false);
+		});
+
 		test('handles non-async callback', async () => {
 			const source = Cell.source(5);
 			const asyncCell = Cell.derivedAsync((get) => get(source) * 2);
@@ -1531,6 +1580,15 @@ describe('Cell.derivedAsync', () => {
 			await vi.advanceTimersByTimeAsync(0);
 			expect(await asyncCell.get()).toBe(10);
 			expect(asyncCell.pending.get()).toBe(false);
+		});
+
+		test('settled reads reuse the active value promise', async () => {
+			const asyncCell = Cell.derivedAsync(() => 42);
+
+			await vi.advanceTimersByTimeAsync(0);
+			expect(await asyncCell.get()).toBe(42);
+			expect(asyncCell.get()).toBe(asyncCell.wvalue);
+			expect(asyncCell.peek()).toBe(asyncCell.wvalue);
 		});
 
 		test('stores null and undefined correctly', async () => {
@@ -1601,6 +1659,24 @@ describe('Cell.derivedAsync', () => {
 			await vi.advanceTimersByTimeAsync(20);
 			expect(await asyncCell.get()).toBe('B');
 			expect(values.filter((v) => v === 'A').length).toBe(0);
+		});
+
+		test('reads started before a restart resolve the latest run', async () => {
+			const source = Cell.source(1);
+			const asyncCell = Cell.derivedAsync(async (get) => {
+				const value = get(source);
+				await new Promise((resolve) => setTimeout(resolve, 20));
+				return value * 10;
+			});
+
+			const first = asyncCell.get();
+			const second = asyncCell.get();
+			await vi.advanceTimersByTimeAsync(5);
+			source.set(2);
+			const third = asyncCell.get();
+			await vi.advanceTimersByTimeAsync(30);
+
+			expect(await Promise.all([first, second, third])).toEqual([20, 20, 20]);
 		});
 
 		test('rapid updates only commit final result', async () => {
@@ -1743,6 +1819,27 @@ describe('Cell.derivedAsync', () => {
 
 			expect(asyncCell.error.get()).toBeInstanceOf(Error);
 			expect(await asyncCell.get()).toBe('valid');
+		});
+
+		test('synchronous callback errors preserve the stable value', async () => {
+			const shouldFail = Cell.source(false);
+			const asyncCell = Cell.derivedAsync((get) => {
+				if (get(shouldFail)) throw new Error('Synchronous failure');
+				return 'stable';
+			});
+
+			await vi.advanceTimersByTimeAsync(0);
+			expect(await asyncCell.get()).toBe('stable');
+
+			shouldFail.set(true);
+			await vi.advanceTimersByTimeAsync(0);
+			expect(await asyncCell.get()).toBe('stable');
+			expect(asyncCell.error.get()?.message).toBe('Synchronous failure');
+
+			shouldFail.set(false);
+			await vi.advanceTimersByTimeAsync(0);
+			expect(await asyncCell.get()).toBe('stable');
+			expect(asyncCell.error.get()).toBeNull();
 		});
 
 		test('error clears on successful recovery', async () => {
@@ -2178,6 +2275,39 @@ describe('Cell.derivedAsync', () => {
 			expect(a.pending.get()).toBe(false);
 			expect(b.pending.get()).toBe(false);
 			expect(c.pending.get()).toBe(false);
+		});
+
+		test('simultaneous async parents schedule one child recomputation', async () => {
+			const sourceA = Cell.source(1);
+			const sourceB = Cell.source(2);
+			const parentA = Cell.derivedAsync(async (get) => {
+				const value = get(sourceA);
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				return value;
+			});
+			const parentB = Cell.derivedAsync(async (get) => {
+				const value = get(sourceB);
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				return value;
+			});
+			const computeChild = vi.fn(async (get) => {
+				const [a, b] = await Promise.all([get(parentA), get(parentB)]);
+				return a + b;
+			});
+			const child = Cell.derivedAsync(computeChild);
+
+			await vi.advanceTimersByTimeAsync(20);
+			expect(await child.get()).toBe(3);
+			computeChild.mockClear();
+
+			Cell.batch(() => {
+				sourceA.set(10);
+				sourceB.set(20);
+			});
+			await vi.advanceTimersByTimeAsync(20);
+
+			expect(await child.get()).toBe(30);
+			expect(computeChild).toHaveBeenCalledTimes(1);
 		});
 
 		test('multiple async parents changing concurrently resolve correctly', async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3329,6 +3329,41 @@ describe('Cell.derivedAsync', () => {
 		});
 	});
 
+	describe('Dependency reconciliation', () => {
+		beforeEach(() => vi.useFakeTimers());
+		afterEach(() => vi.useRealTimers());
+
+		test('async cells detach dependencies from inactive branches', async () => {
+			const useA = Cell.source(true);
+			const a = Cell.source(1);
+			const b = Cell.source(2);
+			const compute = vi.fn(async (get) => {
+				const active = get(useA);
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				return active ? get(a) : get(b);
+			});
+			const value = Cell.derivedAsync(compute);
+
+			await vi.advanceTimersByTimeAsync(10);
+			expect(await value.get()).toBe(1);
+
+			useA.set(false);
+			await vi.advanceTimersByTimeAsync(10);
+			expect(await value.get()).toBe(2);
+			expect(a.derivations.size).toBe(0);
+
+			a.set(10);
+			await vi.advanceTimersByTimeAsync(20);
+			expect(await value.get()).toBe(2);
+			expect(compute).toHaveBeenCalledTimes(2);
+
+			b.set(20);
+			await vi.advanceTimersByTimeAsync(10);
+			expect(await value.get()).toBe(20);
+			expect(compute).toHaveBeenCalledTimes(3);
+		});
+	});
+
 	describe('Async Deadlock on Dispose', () => {
 		test('Should release downstream cells immediately upon disposal', async () => {
 			const context = Cell.context();
@@ -3360,6 +3395,32 @@ describe('Cell.derivedAsync', () => {
 			await expect(
 				Promise.race([downstream.get(), timeout]),
 			).resolves.not.toThrow();
+		});
+
+		test('Disposed async cells cannot attach delayed dependencies', async () => {
+			let release;
+			const source = Cell.source(1);
+			const context = Cell.context();
+			const compute = vi.fn();
+
+			Cell.runWithContext(context, () => {
+				Cell.derivedAsync(async (get) => {
+					compute();
+					await new Promise((resolve) => {
+						release = resolve;
+					});
+					return get(source);
+				});
+			});
+
+			context.destroy();
+			release();
+			await new Promise((resolve) => setTimeout(resolve));
+
+			expect(source.derivations.size).toBe(0);
+			source.set(2);
+			await new Promise((resolve) => setTimeout(resolve));
+			expect(compute).toHaveBeenCalledTimes(1);
 		});
 	});
 });
@@ -3466,6 +3527,27 @@ describe('Derived Cells', () => {
 		b.set(20);
 		expect(cb).toHaveBeenCalledTimes(3);
 		expect(c.get()).toEqual(25);
+	});
+
+	test('derived cells detach dependencies from inactive branches', () => {
+		const useA = Cell.source(true);
+		const a = Cell.source(1);
+		const b = Cell.source(2);
+		const compute = vi.fn(() => (useA.get() ? a.get() : b.get()));
+		const value = Cell.derived(compute);
+
+		expect(value.get()).toBe(1);
+		useA.set(false);
+		expect(value.get()).toBe(2);
+		expect(a.derivations.size).toBe(0);
+
+		a.set(10);
+		expect(value.get()).toBe(2);
+		expect(compute).toHaveBeenCalledTimes(2);
+
+		b.set(20);
+		expect(value.get()).toBe(20);
+		expect(compute).toHaveBeenCalledTimes(3);
 	});
 });
 
@@ -3626,6 +3708,55 @@ describe('Tracking contexts', () => {
 			source.set(30);
 
 			expect(derivedValue).toBe(40);
+		});
+
+		test('Context destruction detaches dependencies discovered later', () => {
+			const useB = Cell.source(false);
+			const a = Cell.source(1);
+			const b = Cell.source(2);
+			const context = Cell.context();
+			const compute = vi.fn(() => (useB.get() ? b.get() : a.get()));
+			let derived;
+
+			Cell.runWithContext(context, () => {
+				derived = Cell.derived(compute);
+			});
+
+			expect(derived.get()).toBe(1);
+			useB.set(true);
+			expect(derived.get()).toBe(2);
+			expect(a.derivations.size).toBe(0);
+			expect(b.derivations.size).toBe(1);
+
+			context.destroy();
+
+			expect(useB.derivations.size).toBe(0);
+			expect(b.derivations.size).toBe(0);
+			b.set(3);
+			expect(compute).toHaveBeenCalledTimes(2);
+		});
+
+		test('Disposed derivations sever downstream graph edges', () => {
+			const source = Cell.source(1);
+			const context = Cell.context();
+			let inner;
+
+			Cell.runWithContext(context, () => {
+				inner = Cell.derived(() => source.get() * 2);
+			});
+			const outer = Cell.derived(() => inner.get() + 1);
+
+			expect(inner.derivations.has(outer)).toBe(true);
+			expect(outer.sources.has(inner)).toBe(true);
+
+			context.destroy();
+
+			expect(inner.derivations.size).toBe(0);
+			expect(outer.sources.has(inner)).toBe(false);
+
+			const retainedRead = Cell.derived(() => inner.get());
+			expect(inner.derivations.size).toBe(0);
+			expect(retainedRead.sources.size).toBe(0);
 		});
 
 		test('Nested contexts should handle stack correctly', () => {


### PR DESCRIPTION
Cells now keep derivations in a strong Set, ensuring updates remain deterministic when LocalContext disposes derivations. This removes the InternallyWeakSet implementation that relied on WeakRef cleanup during iteration, simplifying memory management without relying on GC timing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reactive update scheduling, batching, and effect ordering for more reliable state changes.
  * Fixed asynchronous derived values to handle errors, concurrent updates, stale reads, and dependency changes correctly.
  * Improved cleanup when contexts or derived cells are disposed, preventing stale relationships from being retained.

* **Documentation**
  * Clarified strong references for derived dependents and explicit disposal through `LocalContext`.

* **Tests**
  * Expanded coverage for reactive, asynchronous, batching, and disposal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->